### PR TITLE
Use codesplitting for generator files

### DIFF
--- a/src/routes/Nav.svelte
+++ b/src/routes/Nav.svelte
@@ -17,8 +17,11 @@
 					<a
 						{href}
 						class={href === $page.url.pathname ? '!bg-primary-500' : ''}
-						on:click={() => menuStore.set(false)}>{name}</a
+						data-sveltekit-prefetch
+						on:click={() => menuStore.set(false)}
 					>
+						{name}
+					</a>
 				</li>
 			{/each}
 		</ul>

--- a/src/routes/character_generator/+page.ts
+++ b/src/routes/character_generator/+page.ts
@@ -6,24 +6,16 @@ type DataType = {
 
 type Mapping = { [name: string]: GeneratorDict };
 
-async function importDicts() {
-	return (
-		await Promise.all([
-			{ name: 'Base', dict: (await import('$lib/data/generator_basic_acks.yaml')).default },
-			{
-				name: 'Circle of Dawn',
-				dict: (await import('$lib/data/generator_circle_of_dawn.yaml')).default
-			}
-		])
-	).reduce<Mapping>((acc, dict) => {
-		acc[dict.name] = dict.dict as GeneratorDict;
-		return acc;
-	}, {});
+async function importDicts(): Promise<Mapping> {
+	return {
+		Base: (await import('$lib/data/generator_basic_acks.yaml')).default as GeneratorDict,
+		'Circle of Dawn': (await import('$lib/data/generator_circle_of_dawn.yaml'))
+			.default as GeneratorDict
+	};
 }
 
 export async function load(): Promise<DataType> {
-	const generatorDicts = await importDicts();
 	return {
-		generatorDicts: generatorDicts
+		generatorDicts: await importDicts()
 	};
 }

--- a/src/routes/character_generator/+page.ts
+++ b/src/routes/character_generator/+page.ts
@@ -1,16 +1,29 @@
-import basicGeneratorDict from '$lib/data/generator_basic_acks.yaml';
-import circleOfDawnDict from '$lib/data/generator_circle_of_dawn.yaml';
 import type { GeneratorDict } from '$lib/generator_dict/generator_dict';
 
 type DataType = {
-	generatorDicts: { [name: string]: GeneratorDict };
+	generatorDicts: Mapping;
 };
 
+type Mapping = { [name: string]: GeneratorDict };
+
+async function importDicts() {
+	return (
+		await Promise.all([
+			{ name: 'Base', dict: (await import('$lib/data/generator_basic_acks.yaml')).default },
+			{
+				name: 'Circle of Dawn',
+				dict: (await import('$lib/data/generator_circle_of_dawn.yaml')).default
+			}
+		])
+	).reduce<Mapping>((acc, dict) => {
+		acc[dict.name] = dict.dict as GeneratorDict;
+		return acc;
+	}, {});
+}
+
 export async function load(): Promise<DataType> {
+	const generatorDicts = await importDicts();
 	return {
-		generatorDicts: {
-			Basic: basicGeneratorDict,
-			'Circle of Dawn': circleOfDawnDict
-		}
+		generatorDicts: generatorDicts
 	};
 }


### PR DESCRIPTION
By codesplitting the generator files can be cached by browsers even when the application is updated, as long as the generators itself don't change.

Prefetching is applied for the links in the navigation, so when a user hovers over the character_generator link the generators start to load in the background.
This leads to a better perceived loading time of the character generator page on desktops.
